### PR TITLE
Fix api route for killButton

### DIFF
--- a/docker-images/lagopus-server/templates/jobs.html
+++ b/docker-images/lagopus-server/templates/jobs.html
@@ -46,7 +46,7 @@
                   $("#killButton").click(function() {
                     $.ajax({
                       type: "post",
-                      url: "api/jobs/{{ job["job_id"] }}",
+                      url: "api/jobs/{{ job["job_id"] }}/control",
                       data: JSON.stringify({
                         "action": "kill"
                       }),


### PR DESCRIPTION
There is a lack of '/control' path in the API route used by killButton